### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tool that allow extract endpoints from APK files
 ## Install
 1) Install `apkurlgrep`
 ```
-▶ go get -u github.com/ndelphit/apkurlgrep
+▶ go install github.com/ndelphit/apkurlgrep@latest
 ```
 2) Install [apktool](https://ibotpeaches.github.io/Apktool/install/)
 


### PR DESCRIPTION
Installing executables with "go get" in module mode is deprecated.
"go install pkg@version" should be used instead.
For more information, see https://golang.org/doc/go-get-install-deprecation
